### PR TITLE
Internal API improvements about JoinType

### DIFF
--- a/src/main/java/com/kodgemisi/specification/CriteriaOperation.java
+++ b/src/main/java/com/kodgemisi/specification/CriteriaOperation.java
@@ -5,11 +5,10 @@ package com.kodgemisi.specification;
  *
  * @author Destan Sarpkaya
  * @author Ersan Ceylan
+ * @author Sedat Gokcen
  */
-enum CriteriaOperation {
+enum CriteriaOperation implements Operation {
 
-	JOIN,
-	JOIN_FETCH,
 	EQUAL,
 	EQUAL_TO_MANY,
 	EQUAL_TO_ONE,

--- a/src/main/java/com/kodgemisi/specification/FilterCriteria.java
+++ b/src/main/java/com/kodgemisi/specification/FilterCriteria.java
@@ -4,14 +4,13 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.lang.NonNull;
 
-import javax.persistence.criteria.JoinType;
-
 /**
  * Created on October, 2018
  *
  * @author Destan Sarpkaya
  * @author Ersan Ceylan
  * @author Gökhan Birinci
+ * @author Sedat Gokcen
  */
 
 /**
@@ -28,38 +27,25 @@ class FilterCriteria<T> {
 	private final T value;
 
 	@NonNull
-	private final CriteriaOperation operation;
-
-	private final JoinType joinType;
+	private final Operation operation;
 
 	private final Class<T> clazz;
 
 	private final RelationType relationType;
 
-	FilterCriteria(String key, T value, CriteriaOperation operation, Class<T> clazz) {
+	FilterCriteria(String key, T value, Operation operation, Class<T> clazz, RelationType relationType) {
 		this.key = key;
 		this.value = value;
 		this.operation = operation;
-		this.joinType = null;
-		this.clazz = clazz;
-		this.relationType = RelationType.NO_RELATION;
-	}
-
-	FilterCriteria(String key, T value, CriteriaOperation operation, Class<T> clazz, RelationType relationType) {
-		this.key = key;
-		this.value = value;
-		this.operation = operation;
-		this.joinType = null;
 		this.clazz = clazz;
 		this.relationType = relationType;
 	}
 
-	FilterCriteria(String key, CriteriaOperation operation, JoinType joinType, Class<T> clazz) {
-		this.key = key;
-		this.operation = operation;
-		this.joinType = joinType;
-		this.clazz = clazz;
-		this.value = null;
-		this.relationType = RelationType.NO_RELATION;
+	FilterCriteria(String key, T value, Operation operation, Class<T> clazz) {
+		this(key, value, operation, clazz, RelationType.NO_RELATION);
+	}
+
+	FilterCriteria(String key, Operation operation, Class<T> clazz) {
+		this(key, null, operation, clazz, RelationType.NO_RELATION);
 	}
 }

--- a/src/main/java/com/kodgemisi/specification/GenericSpecificationBuilder.java
+++ b/src/main/java/com/kodgemisi/specification/GenericSpecificationBuilder.java
@@ -27,6 +27,7 @@ import java.util.List;
  * @author Destan Sarpkaya
  * @author Ersan Ceylan
  * @author Gökhan Birinci
+ * @author Sedat Gokcen
  */
 public class GenericSpecificationBuilder<E> {
 
@@ -55,8 +56,8 @@ public class GenericSpecificationBuilder<E> {
 		return new GenericSpecificationBuilder<>();
 	}
 
-	private GenericSpecificationBuilder<E> addCriteria(String key, CriteriaOperation operation, JoinType joinType) {
-		filterCriteriaList.add(new FilterCriteria<Void>(key, operation, joinType, Void.class));
+	private GenericSpecificationBuilder<E> addCriteria(String key, Operation operation) {
+		filterCriteriaList.add(new FilterCriteria<Void>(key, operation, Void.class));
 		return this;
 	}
 
@@ -82,7 +83,7 @@ public class GenericSpecificationBuilder<E> {
 	 * @return
 	 */
 	public GenericSpecificationBuilder<E> join(String key) {
-		return addCriteria(key, CriteriaOperation.JOIN, JoinType.INNER);
+		return addCriteria(key, JoinOperation.JOIN.type(JoinType.INNER));
 	}
 
 	/**
@@ -92,7 +93,7 @@ public class GenericSpecificationBuilder<E> {
 	 * @return
 	 */
 	public GenericSpecificationBuilder<E> join(String key, JoinType joinType) {
-		return addCriteria(key, CriteriaOperation.JOIN, joinType);
+		return addCriteria(key, JoinOperation.JOIN.type(joinType));
 	}
 
 	/**
@@ -101,7 +102,7 @@ public class GenericSpecificationBuilder<E> {
 	 * @return
 	 */
 	public GenericSpecificationBuilder<E> joinFetch(String key) {
-		return addCriteria(key, CriteriaOperation.JOIN_FETCH, JoinType.INNER);
+		return addCriteria(key, JoinOperation.JOIN_FETCH.type(JoinType.INNER));
 	}
 
 	/**
@@ -111,7 +112,7 @@ public class GenericSpecificationBuilder<E> {
 	 * @return
 	 */
 	public GenericSpecificationBuilder<E> joinFetch(String key, JoinType joinType) {
-		return addCriteria(key, CriteriaOperation.JOIN_FETCH, joinType);
+		return addCriteria(key, JoinOperation.JOIN_FETCH.type(joinType));
 	}
 
 	/**

--- a/src/main/java/com/kodgemisi/specification/JoinOperation.java
+++ b/src/main/java/com/kodgemisi/specification/JoinOperation.java
@@ -1,0 +1,24 @@
+package com.kodgemisi.specification;
+
+import javax.persistence.criteria.JoinType;
+
+/**
+ * Created on November, 2018
+ *
+ * @author Sedat Gokcen
+ */
+public enum JoinOperation implements Operation {
+    JOIN,
+    JOIN_FETCH;
+
+    private JoinType type = JoinType.INNER;
+
+    public JoinOperation type(JoinType type) {
+        this.type = type;
+        return this;
+    }
+
+    public JoinType getType() {
+        return type;
+    }
+}

--- a/src/main/java/com/kodgemisi/specification/Operation.java
+++ b/src/main/java/com/kodgemisi/specification/Operation.java
@@ -1,0 +1,9 @@
+package com.kodgemisi.specification;
+
+/**
+ * Created on November, 2018
+ *
+ * @author Sedat Gokcen
+ */
+interface Operation {
+}


### PR DESCRIPTION
The [previous implementation](https://github.com/kodgemisi/specification-builder/pull/2) is very open to runtime exceptions as it's accepting `JoinType` with every operation rather than accepting it only with `JOIN` and `JOIN_FETCH` operations.

Naming can be improved though, instead of `Operation -> JoinOperation & CriteriaOperation`, `CriteriaOperation -> JoinOperation & OtherOperation` can be used or  maybe something else.

**Haven't tried it with a sample application**. It may not work but still you got the idea :D