### PR TITLE
add likeIgnoreCase method, closes #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ It's enough to add this dependency to use this library.
  				.greaterThanOrEqualTo("birthDate", minBirthDate)
  				.lessThanOrEqualTo("birthDate", maxBirthDate)
  				.like("about", keyword)
+ 				.likeIgnoreCase("about", keyword)
  				.in("city", cities)
  				.custom(customSpecification)
  				.build();

--- a/src/main/java/com/kodgemisi/specification/CriteriaOperation.java
+++ b/src/main/java/com/kodgemisi/specification/CriteriaOperation.java
@@ -14,6 +14,7 @@ enum CriteriaOperation {
 	EQUAL_TO_MANY,
 	EQUAL_TO_ONE,
 	LIKE,
+	LIKE_IGNORE_CASE,
 	IS_NULL,
 	IS_NOT_NULL,
 	IN,

--- a/src/main/java/com/kodgemisi/specification/FilterCriteria.java
+++ b/src/main/java/com/kodgemisi/specification/FilterCriteria.java
@@ -38,9 +38,6 @@ class FilterCriteria<T> {
 
 	private final ConditionType conditionType;
 
-	// TODO: it should not be constant value
-	private final boolean caseSensitive = false;
-
 	FilterCriteria(String key, T value, CriteriaOperation operation, Class<T> clazz, ConditionType conditionType) {
 		this.key = key;
 		this.value = value;

--- a/src/main/java/com/kodgemisi/specification/GenericSpecification.java
+++ b/src/main/java/com/kodgemisi/specification/GenericSpecification.java
@@ -70,13 +70,13 @@ class GenericSpecification<E, T, C extends Comparable<? super C>> implements Spe
 		}
 		case LIKE: {
 			final Path<?> path = resolvePath(root, filterCriteria.getKey(), filterCriteria.getRelationType());
-			if (filterCriteria.isCaseSensitive()) {
-				criteriaBuilder.like(path.as(String.class), "%" + filterCriteria.getValue() + "%");
-			}
-			else {
-				return criteriaBuilder.like(criteriaBuilder.lower(path.as(String.class)),
-											"%" + String.valueOf(filterCriteria.getValue()).toLowerCase() + "%");
-			}
+			return criteriaBuilder.like(path.as(String.class), "%" + filterCriteria.getValue() + "%");
+		}
+
+		case LIKE_IGNORE_CASE: {
+			final Path<?> path = resolvePath(root, filterCriteria.getKey(), filterCriteria.getRelationType());
+			final Expression<String> parameterExpression = criteriaBuilder.literal("%" + String.valueOf(filterCriteria.getValue()) + "%");
+			return criteriaBuilder.like(criteriaBuilder.upper(path.as(String.class)), criteriaBuilder.upper(parameterExpression));
 		}
 
 		case IN: {

--- a/src/main/java/com/kodgemisi/specification/GenericSpecificationBuilder.java
+++ b/src/main/java/com/kodgemisi/specification/GenericSpecificationBuilder.java
@@ -210,6 +210,39 @@ public class GenericSpecificationBuilder<E> {
 		return addCriteria(key, value, CriteriaOperation.LIKE, relationType);
 	}
 
+	/**
+	 * Adds a new ignore-case "like" criteria to the filterCriteriaList
+	 * <blockquote><pre>
+	 *     GenericSpecificationBuilder.of(Person.class)
+	 *     	.likeIgnoreCase("bio", keyword)
+	 *     	.build();
+	 * </pre></blockquote>
+	 *
+	 * @param key   field name
+	 * @param value
+	 * @return
+	 */
+	public GenericSpecificationBuilder<E> likeIgnoreCase(String key, Object value) {
+		return addCriteria(key, value, CriteriaOperation.LIKE_IGNORE_CASE, RelationType.NO_RELATION);
+	}
+
+	/**
+	 * Adds a new ignore-case "like" criteria to the filterCriteriaList by joining to given relation
+	 * In order to define a relation, you must use "." delimiter after relation name
+	 * <blockquote><pre>
+	 *     GenericSpecificationBuilder.of(Person.class)
+	 *     	.likeIgnoreCase("department.name", departmentName, {@link com.kodgemisi.specification.RelationType} RelationType.TO_ONE)
+	 *     	.build();
+	 * </pre></blockquote>
+	 *
+	 * @param key   field name
+	 * @param value
+	 * @return
+	 */
+	public GenericSpecificationBuilder<E> likeIgnoreCase(String key, Object value, RelationType relationType) {
+		return addCriteria(key, value, CriteriaOperation.LIKE_IGNORE_CASE, relationType);
+	}
+
 	public GenericSpecificationBuilder<E> isNull(String key) {
 		return addCriteria(key, CriteriaOperation.IS_NULL);
 	}


### PR DESCRIPTION
`likeIgnoreCase` method creates a clause as below:
```
    ....
    where
        upper(user0_.name) like upper(?)
```
Spring Data JPA Derived Query methods also add this clause for methods with `ignoreCase` option. 
